### PR TITLE
Bump to liquidsoap 1.3.0

### DIFF
--- a/liquidsoap.spec
+++ b/liquidsoap.spec
@@ -1,13 +1,11 @@
 Name:     liquidsoap 
-Version:  1.2.1
-Release:  3
+Version:  1.3.0
+Release:  1
 Summary:  Liquidsoap by Savonet
 License:  GPLv2
 URL:      http://savonet.sourceforge.net/
 Source0:  https://github.com/savonet/liquidsoap/releases/download/%{version}/liquidsoap-%{version}.tar.bz2
 Source1:  liquidsoap@.service
-# lib64 search path for ladspa https://github.com/savonet/liquidsoap/pull/349
-Patch0:   https://patch-diff.githubusercontent.com/raw/savonet/liquidsoap/pull/349.patch
 
 BuildRequires: libstdc++-static
 BuildRequires: ocaml
@@ -34,8 +32,6 @@ BuildRequires: ocaml-flac
 BuildRequires: flac-devel
 BuildRequires: ocaml-speex
 BuildRequires: speex-devel
-BuildRequires: ocaml-schroedinger
-BuildRequires: schroedinger-devel
 BuildRequires: ocaml-xmlm-devel
 BuildRequires: ocaml-xmlm
 BuildRequires: ocaml-xmlplaylist
@@ -70,15 +66,13 @@ components working together.
 
 %prep
 %setup -q 
-%patch0 -p1
-./configure --disable-camomile --prefix=%{_exec_prefix} --sysconfdir=/etc --mandir=/usr/share/man --localstatedir=/var
+./configure --disable-camomile --prefix=%{_exec_prefix} --sysconfdir=/etc --mandir=/usr/share/man --localstatedir=/var --disable-ldconf
 
 %build
 make
 
 %install
 make install DESTDIR=%{buildroot}%{_exec_prefix} OCAMLFIND_DESTDIR=%{buildroot}%{_exec_prefix} prefix=%{buildroot}%{_exec_prefix} sysconfdir=%{buildroot}/etc mandir=%{buildroot}%{_exec_prefix}/share/man localstatedir=%{buildroot}/var
-/bin/install -c scripts/liquidtts %{buildroot}%{_exec_prefix}/lib/%{name}/%{version}
 /bin/install -d %{buildroot}%{_exec_prefix}/lib/systemd/system/
 /bin/install -c %{SOURCE1} -m 644 %{buildroot}%{_exec_prefix}/lib/systemd/system/
 
@@ -94,8 +88,8 @@ exit 0
 %{_exec_prefix}/lib/systemd/system/liquidsoap@.service
 %config/etc/liquidsoap/radio.liq.example
 %config/etc/logrotate.d/liquidsoap
-%{_exec_prefix}/lib/liquidsoap/1.2.1/
+%{_exec_prefix}/lib/liquidsoap/%{version}/
 %doc README
 %doc
-%{_exec_prefix}/share/doc/liquidsoap-1.2.1/examples/*.liq
+%{_exec_prefix}/share/doc/liquidsoap-%{version}/examples/*.liq
 %{_exec_prefix}/share/man/man1/liquidsoap.1.gz


### PR DESCRIPTION
Configure output is below:

```
 * Supported input formats
   - Vorbis            : yes
   - Theora            : yes
   - Speex             : yes
   - Flac (native)     : yes
   - Flac (ogg)        : yes
   - MP3               : yes
   - AAC               : yes
   - XML playlists     : yes
   - Lastfm            : no (requires lastfm)

 * Supported output formats
   - Vorbis            : yes
   - MP3               : yes
   - MP3 (fixed-point) : no (requires shine)
   - FDK-AAC           : yes
   - SPEEX             : yes
   - Opus              : yes
   - Theora            : yes

 * Tags
   - Taglib (ID3 tags) : yes
   - Vorbis            : yes
   - charset detection : no (requires camomile)

 * Input / output
   - Icecast/Shoutcast : yes
   - AO                : no (requires ao)
   - OSS               : yes
   - ALSA              : yes
   - Portaudio         : no (requires portaudio)
   - Pulseaudio        : no (requires pulseaudio)
   - JACK              : no (requires bjack)
   - GStreamer         : no (requires gstreamer)

 * Audio manipulation
   - Samplerate        : yes
   - SoundTouch        : yes
   - LADSPA            : yes

 * Video manipulation
   - Gavl              : no (requires gavl)
   - FFmpeg            : no (requires ffmpeg)
   - frei0r            : no (requires frei0r)
   - camlimages        : no (requires camlimages)

 * MIDI manipulation
   - DSSI              : no (requires dssi)

 * Visualization
   - Graphics          : yes
   - SDL               : no (requires sdl)
   - GD                : no (requires gd)

 * Additional libraries
   - curl URI resolver : requires curl at runtime
   - dynlink           : yes
   - inotify           : yes
   - lo                : no (requires lo)
   - magic             : yes
   - yojson            : yes
   - ssl               : no (requires ssl)
   - SecureTransport   : no (requires osx-secure-transport)
   - windows service   : no (requires winsvc)

 * Graphical interfaces
   - Python GUI        : no
```

SSL requires ocaml-ssl >= 0.5.2 which is in Fedora 24 and has not made it into EPEL 7.

Fix #8 
Fix #9 