### PR TITLE
Update to liquidsoap 1.3.1

### DIFF
--- a/liquidsoap.spec
+++ b/liquidsoap.spec
@@ -1,12 +1,11 @@
 Name:     liquidsoap 
-Version:  1.3.0
-Release:  2
+Version:  1.3.1
+Release:  1
 Summary:  Liquidsoap by Savonet
 License:  GPLv2
 URL:      http://savonet.sourceforge.net/
 Source0:  https://github.com/savonet/liquidsoap/releases/download/%{version}/liquidsoap-%{version}.tar.bz2
 Source1:  liquidsoap@.service
-Patch0:   https://github.com/savonet/liquidsoap/commit/a9ef199e9ac9087f932cfd1c379bfa7fe543f341.patch#?/liqidsoap-buffer-add-channel-a9ef199.patch
 
 BuildRequires: libstdc++-static
 BuildRequires: ocaml
@@ -67,8 +66,7 @@ components working together.
 
 %prep
 %setup -q
-%patch -P 0 -p 1
-./configure --disable-camomile --prefix=%{_exec_prefix} --sysconfdir=/etc --mandir=/usr/share/man --localstatedir=/var --disable-ldconf
+./configure --with-internal-glib --disable-camomile --prefix=%{_exec_prefix} --sysconfdir=/etc --mandir=/usr/share/man --localstatedir=/var --disable-ldconf
 
 %build
 make


### PR DESCRIPTION
Removes the 1.3.0 patch for run_process and adds --with-internal-glib to %configure due to "Cannot find pkg-config" error.