### PR TITLE
Configure travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: minimal
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: main
+      name: "RPMlint"
+      before_install:
+        - docker pull quay.io/hairmare/fedora_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/fedora_rpmdev rpmlint liquidsoap.spec
+    - stage: main
+      name: "CentOS RPM"
+      before_install:
+        - docker pull quay.io/hairmare/centos_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos_rpmdev /git/.travis/rpm.sh

--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# RPM build wrapper for liquidsoap, runs inside the build container on travis-ci
+
+set -xe
+
+curl -o /etc/yum.repos.d/liquidsoap.repo https://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/CentOS_7/home:radiorabe:liquidsoap.repo
+
+yum -y install \
+    epel-release \
+    http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+
+chown root:root liquidsoap.spec
+
+rpmdev-setuptree
+
+cp *.service /root/rpmbuild/SOURCES/
+
+build-rpm-package.sh liquidsoap.spec


### PR DESCRIPTION
This adds travis-ci for our liquidsoap packages. Right now this build will fail in any cases (most dependencies have already been refactored but the liquidsoap rpm hasn't).

I've prepared a PR #23 based on this that refactors the liquidsoap package so it doesn't install the whole ocaml dev environment.

I think we should merge this first and then do some real-world testing with the refactored packages that I'm going to attach to my next PR. @paraenggu could you PTAL and merge/review it irregardless of the errors? My next PR will get rid of a heap of rpmlint warnings!