### PR TITLE
Cleanup and use -devel packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ jobs:
       before_install:
         - docker pull quay.io/hairmare/centos_rpmdev
       script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos_rpmdev /git/.travis/rpm.sh
+    - stage: main
+      name: "Fedora RPM"
+      before_install:
+        - docker pull quay.io/hairmare/fedora_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/fedora_rpmdev /git/.travis/rpm.sh

--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -4,11 +4,22 @@
 
 set -xe
 
-curl -o /etc/yum.repos.d/liquidsoap.repo https://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/CentOS_7/home:radiorabe:liquidsoap.repo
+OBS_OS=`source /etc/os-release; echo $ID`
 
-yum -y install \
-    epel-release \
-    http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+case $OBS_OS in
+"centos")
+    OBS_DIST="CentOS_7"
+    yum -y install \
+        epel-release \
+        http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+    ;;
+"fedora")
+    V=`source /etc/os-release; echo $VERSION_ID`
+    OBS_DIST="Fedora_${V}_standard"
+    ;;
+esac
+
+curl -o /etc/yum.repos.d/liquidsoap.repo "https://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/${OBS_DIST}/home:radiorabe:liquidsoap.repo"
 
 chown root:root liquidsoap.spec
 

--- a/liquidsoap.spec
+++ b/liquidsoap.spec
@@ -24,11 +24,12 @@
 
 Name:     liquidsoap 
 Version:  1.3.4
-Release:  1%{?dist}
-Summary:  Liquidsoap by Savonet
+Release:  2%{?dist}
+Summary:  Audio and video streaming language
+
 License:  GPLv2
 URL:      http://liquidsoap.info/
-Source0:  https://github.com/savonet/liquidsoap/releases/download/%{version}/liquidsoap-%{version}.tar.bz2
+Source0:  https://github.com/savonet/liquidsoap/releases/download/%{version}/%{name}-%{version}.tar.bz2
 Source1:  liquidsoap@.service
 
 BuildRequires: file-devel
@@ -43,62 +44,62 @@ BuildRequires: libstdc++-static
 BuildRequires: libvorbis-devel
 BuildRequires: ocaml
 BuildRequires: ocaml-alsa-devel
-BuildRequires: ocaml-biniou
 BuildRequires: ocaml-biniou-devel
-BuildRequires: ocaml-cry
-BuildRequires: ocaml-dtools
-BuildRequires: ocaml-duppy
-BuildRequires: ocaml-easy-format
+BuildRequires: ocaml-cry-devel
+BuildRequires: ocaml-dtools-devel
+BuildRequires: ocaml-duppy-devel
 BuildRequires: ocaml-easy-format-devel
 BuildRequires: ocaml-findlib
-BuildRequires: ocaml-flac
-BuildRequires: ocaml-inotify
+BuildRequires: ocaml-flac-devel
+BuildRequires: ocaml-inotify-devel
 BuildRequires: ocaml-bjack-devel
-BuildRequires: ocaml-ladspa
-BuildRequires: ocaml-lame
-BuildRequires: ocaml-magic
-BuildRequires: ocaml-mm
-BuildRequires: ocaml-opus
-BuildRequires: ocaml-samplerate
-BuildRequires: ocaml-soundtouch
-BuildRequires: ocaml-speex
+BuildRequires: ocaml-ladspa-devel
+BuildRequires: ocaml-lame-devel
+BuildRequires: ocaml-magic-devel
+BuildRequires: ocaml-mm-devel
+BuildRequires: ocaml-ogg-devel
+BuildRequires: ocaml-opus-devel
+BuildRequires: ocaml-pcre-devel
+BuildRequires: ocaml-samplerate-devel
+BuildRequires: ocaml-soundtouch-devel
+BuildRequires: ocaml-speex-devel
 BuildRequires: ocaml-ssl-devel
-BuildRequires: ocaml-taglib
+BuildRequires: ocaml-taglib-devel
 BuildRequires: ocaml-theora-devel
-BuildRequires: ocaml-vorbis >= 0.7.0
-BuildRequires: ocaml-xmlm
+BuildRequires: ocaml-vorbis-devel
 BuildRequires: ocaml-xmlm-devel
-BuildRequires: ocaml-xmlplaylist
+BuildRequires: ocaml-xmlplaylist-devel
 BuildRequires: ocaml-yojson-devel
 BuildRequires: opus-devel
-BuildRequires: ocaml-pcre-devel
 BuildRequires: soundtouch-devel
 BuildRequires: speex-devel
 BuildRequires: systemd
 BuildRequires: taglib-devel
-
+%{?systemd_requires}
 Requires(pre): shadow-utils
 
-Requires: lame
-Requires: libmad
 
 %description
-Liquidsoap is a powerful and flexible language for describing your streams. It offers a rich collection of
-operators that you can combine at will, giving you more power than you need for creating or transforming
-streams. But liquidsoap is still very light and easy to use, in the Unix tradition of simple strong
+Liquidsoap is a powerful and flexible language for describing your streams. It
+offers a rich collection of operators that you can combine at will, giving you
+more power than you need for creating or transforming streams. But liquidsoap
+is still very light and easy to use, in the Unix tradition of simple strong
 components working together.
+
 
 %prep
 %setup -q
-./configure --with-internal-glib --disable-camomile --prefix=%{_exec_prefix} --sysconfdir=/etc --mandir=/usr/share/man --localstatedir=/var --disable-ldconf
+# do not use the configure rpm macro due to this not being a classical autoconf based configure script
+./configure --disable-camomile --prefix=%{_exec_prefix} --sysconfdir=%{_sysconfdir} --mandir=%{_mandir} --localstatedir=%{_localstatedir} --disable-ldconf
 
 %build
 make
 
 %install
-%make_install%{_exec_prefix} OCAMLFIND_DESTDIR=%{buildroot}%{_exec_prefix} prefix=%{buildroot}%{_exec_prefix} sysconfdir=%{buildroot}/etc mandir=%{buildroot}%{_exec_prefix}/share/man localstatedir=%{buildroot}/var
-/bin/install -d %{buildroot}%{_unitdir}
-/bin/install -c %{SOURCE1} -m 644 %{buildroot}%{_unitdir}
+# do not use the make_install rpm macro due to this not being a classical automake based makefile
+make install %{_exec_prefix} OCAMLFIND_DESTDIR=%{buildroot}%{_exec_prefix} prefix=%{buildroot}%{_exec_prefix} sysconfdir=%{buildroot}%{_sysconfdir} mandir=%{buildroot}%{_mandir} localstatedir=%{buildroot}%{_localstatedir}
+install -d %{buildroot}%{_unitdir}
+install -c %{SOURCE1} -m 644 %{buildroot}%{_unitdir}
 
 %pre
 getent group liquidsoap >/dev/null || groupadd -r liquidsoap
@@ -120,9 +121,14 @@ exit 0
 %{_exec_prefix}/bin/liquidsoap
 %{_unitdir}/liquidsoap@.service
 %config/etc/liquidsoap/radio.liq.example
-%config/etc/logrotate.d/liquidsoap
+%config(noreplace)/etc/logrotate.d/liquidsoap
 %{_exec_prefix}/lib/liquidsoap/%{version}/
 %doc README
 %doc
 %{_exec_prefix}/share/doc/liquidsoap-%{version}/examples/*.liq
 %{_mandir}/man1/liquidsoap.1.*
+
+%changelog
+* Mon Dec 10 2018 Lucas Bickel <hairmare@rabe.ch> - 1.3.4-2
+- Initialize RPM changelog
+- Proper installation of runtime deps


### PR DESCRIPTION
Refactors the liquidsoap package to use the -devel packages I built for all of our centos-rpm-ocaml-* packages and makes the final install much more lightweight since we only install the final static binary in the refactored packages.

Also takes care of cleaning up the specfile to get rid of any rpmlint errors. Following is the rpmlint output... 

```
# rpmlint liquidsoap.spec liquidsoap-1.3.4-2.el7.x86_64.rpm 
liquidsoap.spec:91: W: configure-without-libdir-spec
```
liquidsoap does not use a standard C-style autoconf configure script, though it's similar we don't need to pass libdir since we're building a static binary anyway,
```
liquidsoap.spec: W: invalid-url Source0: https://github.com/savonet/liquidsoap/releases/download/1.3.4/liquidsoap-1.3.4.tar.bz2 HTTP Error 403: Forbidden
```
We need to use the full tarball that contains the m4 macros need to build, these aren't a regular GitHub tarball but rather an uploaded release artefact. The releases page does not support HEAD requests.
```
liquidsoap.x86_64: W: only-non-binary-in-usr-lib
```
This is currently the liquidsoap way to store stuff like pervasives.liq and the location in the libdir is hardcoded in liquidsoap. I could change this during %setup but would risk our liquidsoap workig slightly different than anything mentioned in the docs.
```
liquidsoap.x86_64: W: conffile-without-noreplace-flag /etc/liquidsoap/radio.liq.example
```
This is just a warning and the example should get replaced on updates since a liquidsoap file should end with `.liq` anyway.  Maybe the sane thing would be to remove the file completely, but then again, this rpmlint line is just a warning and I do consider myself warned.

The -debuginfo rpm had some additional "E: incorrect-fsf-address" errors, some of which need to be reported and fixed upstream. I fixed those that are fixable with a sed hack and will take care of cleaning this up in upstream at some point in the future... I don't consider this a blocker for these RPMs. That liquidsoap still has an outdated FSF address in their headers isn't really all to critical since I feel getting a hold of them is a easy anyway nowadays.

As promised in #22 I'm uploading some rpm in [liquidsoap.tar.gz](https://github.com/radiorabe/centos-rpm-liquidsoap/files/2664588/liquidsoap.tar.gz). It would be awesome if someone could find some time to test them against their workloads since the changes are pretty substantial (I'll do some LibreTime testing of my own over the next couple of days).

This also fixes what's described in https://github.com/radiorabe/centos-rpm-ocaml-fdkaac/issues/1 for all cases except the linked ocaml-fdkaac issue. If this looks ok I'll try to fix ocaml-fdkaac soonish.