### PR TITLE
Explicit ocaml-mad-devel buildrequire

### DIFF
--- a/liquidsoap.spec
+++ b/liquidsoap.spec
@@ -24,7 +24,7 @@
 
 Name:     liquidsoap 
 Version:  1.3.4
-Release:  2%{?dist}
+Release:  3%{?dist}
 Summary:  Audio and video streaming language
 
 License:  GPLv2
@@ -55,6 +55,7 @@ BuildRequires: ocaml-inotify-devel
 BuildRequires: ocaml-bjack-devel
 BuildRequires: ocaml-ladspa-devel
 BuildRequires: ocaml-lame-devel
+BuildRequires: ocaml-mad-devel
 BuildRequires: ocaml-magic-devel
 BuildRequires: ocaml-mm-devel
 BuildRequires: ocaml-ocamldoc
@@ -151,6 +152,9 @@ exit 0
 %{_docdir}/%{name}-%{version}/examples
 
 %changelog
+* Sun Dec 23 2018 Lucas Bickel <hairmare@rabe.ch> - 1.3.4-3
+- Explicit BuildRequire for ocaml-mad-devel
+
 * Mon Dec 10 2018 Lucas Bickel <hairmare@rabe.ch> - 1.3.4-2
 - Initialize RPM changelog
 - Proper installation of runtime deps


### PR DESCRIPTION
The `dnf builddep` command seems to solve transitive dependencies slightly different that OBS. 

This actually worked on travis but was missing the ocaml-mad-devel package on OBS. This surfaced while I was trying to build i586 packages on OBS (I'm doing i586 since x86_64 is still out of order on OBS).

This only seems to affect Fedora Rawhide for now. Nevertheless the ocaml-mad-devel package should get BuildRequired by the liquidsoap package since it's configure script checks for it to be installed. I think it was getting installed by some other ocaml module that had it as a dep an we were just lucky that the build worked previously.